### PR TITLE
DOC-233: Remove Rails.root from uploader path

### DIFF
--- a/app/uploaders/repo_file_uploader.rb
+++ b/app/uploaders/repo_file_uploader.rb
@@ -17,7 +17,7 @@ class RepoFileUploader < CarrierWave::Uploader::Base
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:
   def store_dir
-    "#{Rails.root.join('uploads')}/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+    "#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
   end
 
   # Provide a default URL as a default if there hasn't been a file uploaded:


### PR DESCRIPTION
RepositoryManager has hardcoded Rails app absolute path
in S3 bucket. This causes issues when application changes
directory, which is after each deploy on DocMa.
