### PR TITLE
IMS-5012: cannot add file with same name as folder and vice versa

### DIFF
--- a/app/models/repository_manager/repo_item.rb
+++ b/app/models/repository_manager/repo_item.rb
@@ -56,7 +56,7 @@ class RepositoryManager::RepoItem < ActiveRecord::Base
         self.errors.add(:move, I18n.t('repository_manager.errors.repo_item.item_exist'))
         # we delete the repo if asked
         self.destroy if options[:destroy_if_fail]
-        raise RepositoryManager::ItemExistException.new("move failed. The repo_#{ self.folder? ? 'folder' : 'file' } '#{name}' already exist in the folder '#{options[:source_folder].name}'")
+        raise RepositoryManager::ItemExistException.new("move failed. The repo_#{ self.is_folder? ? 'folder' : 'file' } '#{name}' already exist in the folder '#{options[:source_folder].name}'")
       elsif children_with_same_name and overwrite
         # If a children with the same name exist and we want to overwrite,
         # We destroy or update it
@@ -82,7 +82,7 @@ class RepositoryManager::RepoItem < ActiveRecord::Base
         self.errors.add(:move, I18n.t('repository_manager.errors.repo_item.item_exist'))
         # we delete the repo if asked
         self.destroy if options[:destroy_if_fail]
-        raise RepositoryManager::ItemExistException.new("move failed. The repo_#{ self.folder? ? 'folder' : 'file' } '#{name}' already exist in the root")
+        raise RepositoryManager::ItemExistException.new("move failed. The repo_#{ self.is_folder? ? 'folder' : 'file' } '#{name}' already exist in the root")
       # else we destroy it
       elsif children_with_same_name and overwrite
         # If a children with the same name exist and we want to overwrite,

--- a/app/models/repository_manager/repo_item.rb
+++ b/app/models/repository_manager/repo_item.rb
@@ -50,13 +50,13 @@ class RepositoryManager::RepoItem < ActiveRecord::Base
         raise RepositoryManager::RepositoryManagerException.new("move failed. target '#{options[:source_folder].name}' can't be a file")
       end
 
-      children_with_same_name = options[:source_folder].get_children_by_name(self.name)
+      children_with_same_name = options[:source_folder].children.where(name: self.name, type: self.type)
       # If the name exist and we don't want to overwrite, we raise an error
       if children_with_same_name and !overwrite
         self.errors.add(:move, I18n.t('repository_manager.errors.repo_item.item_exist'))
         # we delete the repo if asked
         self.destroy if options[:destroy_if_fail]
-        raise RepositoryManager::ItemExistException.new("move failed. The repo_item '#{name}' already exist ine the folder '#{options[:source_folder].name}'")
+        raise RepositoryManager::ItemExistException.new("move failed. The repo_#{ self.folder? ? 'folder' : 'file' } '#{name}' already exist in the folder '#{options[:source_folder].name}'")
       elsif children_with_same_name and overwrite
         # If a children with the same name exist and we want to overwrite,
         # We destroy or update it
@@ -82,7 +82,7 @@ class RepositoryManager::RepoItem < ActiveRecord::Base
         self.errors.add(:move, I18n.t('repository_manager.errors.repo_item.item_exist'))
         # we delete the repo if asked
         self.destroy if options[:destroy_if_fail]
-        raise RepositoryManager::ItemExistException.new("move failed. The repo_item '#{name}' already exist in the root")
+        raise RepositoryManager::ItemExistException.new("move failed. The repo_#{ self.folder? ? 'folder' : 'file' } '#{name}' already exist in the root")
       # else we destroy it
       elsif children_with_same_name and overwrite
         # If a children with the same name exist and we want to overwrite,

--- a/app/models/repository_manager/repo_item.rb
+++ b/app/models/repository_manager/repo_item.rb
@@ -50,7 +50,7 @@ class RepositoryManager::RepoItem < ActiveRecord::Base
         raise RepositoryManager::RepositoryManagerException.new("move failed. target '#{options[:source_folder].name}' can't be a file")
       end
 
-      children_with_same_name = options[:source_folder].children.where(name: self.name, type: self.type)
+      children_with_same_name = options[:source_folder].children.where(name: self.name, type: self.type).first
       # If the name exist and we don't want to overwrite, we raise an error
       if children_with_same_name and !overwrite
         self.errors.add(:move, I18n.t('repository_manager.errors.repo_item.item_exist'))


### PR DESCRIPTION
User cannot add a file with same name as folder
but it should be possible.
This is a fix for bad checking. Mr collaide checks items with same name
but we should check items by name and type.
